### PR TITLE
math/xy_series.py: Provide a better get_avg_value() method..

### DIFF
--- a/xtalx/tools/math/xy_series.py
+++ b/xtalx/tools/math/xy_series.py
@@ -7,21 +7,73 @@ class XYSeries:
         self.X = np.array(X)
         self.Y = np.array(Y)
 
+    def _integrate(self, x0, x1):
+        assert x0 <= x1
+
+        x0, x1 = coords = np.clip([x0, x1], self.X[0], self.X[-1])
+        yL, yH = np.interp(coords, self.X, self.Y)
+        iL, iH = np.searchsorted(self.X, coords)
+        X      = np.concatenate(([x0], self.X[iL:iH], [x1]))
+        Y      = np.concatenate(([yL], self.Y[iL:iH], [yH]))
+        A      = np.trapz(Y, x=X)
+
+        return A, x0, x1
+
+    def integrate(self, x0, x1):
+        '''
+        Integrate the data over the range [x0, x1] using the trapezoidal rule.
+        The endpoints need not coincide with the sample data; the integration
+        will use linear interpolation to integrate just the part of the
+        boundary trapezoid that lies within the range.
+        '''
+        if x0 <= x1:
+            return self._integrate(x0, x1)[0]
+        return -self._integrate(x1, x0)[0]
+
     def get_avg_value(self, x0, x1):
-        indices = (self.X >= x0) & (self.X <= x1)
-        X       = self.X[indices]
-        Y       = self.Y[indices]
-        if len(X) == 0:
-            return None
-        if len(X) == 1:
-            return Y[0]
-
-        area_2  = 0
-        for i in range(len(X) - 1):
-            area_2 += (Y[i + 1] + Y[i]) * (X[i + 1] - X[i])
-
-        return area_2 / (2 * (X[-1] - X[0]))
+        '''
+        Compute the average value of the data over the range [x0, x1].  If the
+        range extends past the endpoints of the data set, the x0 and x1 values
+        will be clipped to the data set endpoints before computing the average
+        value.  If the average value is undefined (x0 == x1 after clipping)
+        then None is returned.
+        '''
+        area, x0, x1 = self._integrate(x0, x1)
+        if x0 != x1:
+            return area / (x1 - x0)
+        return None
 
     def append(self, x, y):
         self.X = np.append(self.X, x)
         self.Y = np.append(self.Y, y)
+
+
+if __name__ == '__main__':
+    s = XYSeries([1, 2, 3], [4, 5, 6])
+    assert s.integrate(1, 1) == 0
+    assert s.integrate(0, 1) == 0
+    assert s.integrate(0, 0.5) == 0
+    assert s.integrate(3, 4) == 0
+    assert s.integrate(3.5, 4) == 0
+    assert s.integrate(0, 4) == 10
+    assert s.integrate(1, 2) == 4.5
+    assert s.integrate(1, 3) == 10
+    assert s.integrate(2, 3) == 5.5
+    assert s.integrate(1.5, 2.5) == 5
+    assert s.integrate(1.5, 1.5) == 0
+
+    s = XYSeries([0, 2, 3, 4], [2, 3, 5, 4])
+    assert s.integrate(-1, 3) == 9
+    assert s.integrate(-1, -0.5) == 0
+    assert s.integrate(3, 5) == 4.5
+    assert s.integrate(4.5, 5) == 0
+    assert s.integrate(-1, 5) == 13.5
+    assert s.integrate(0, 1) == 2.25
+    assert s.integrate(0, 2) == 5
+    assert s.integrate(0, 3) == 9
+    assert s.integrate(0, 4) == 13.5
+    assert s.integrate(0.5, 1.5) == 2.5
+    assert s.integrate(0.5, 2.5) == 5.6875
+    assert s.integrate(2.5, 0.5) == -5.6875
+
+    print('Tests succeeded.')


### PR DESCRIPTION
The previous get_avg_value() implementation was only considering data points within the (x0, x1) bounds and not interpolating the data out to x0 and x1.  This creates unused gaps in the data when resampling, for instance, and it doesn't provide as good of an average as we could get if we used the full range of data from x0 to x1.

We first provide _integrate() to do generic integration and then reimplement get_avg_value() in terms of the new _integrate() method.  A short test sequence is also provided to ensure correctness.